### PR TITLE
use brand and region from container as brand if they are available

### DIFF
--- a/includes/MarketplaceApi.php
+++ b/includes/MarketplaceApi.php
@@ -32,12 +32,25 @@ class MarketplaceApi {
 					
 					$marketplace = get_transient( self::TRANSIENT );
 
-					if ( false === $marketplace ) { 
-
-						$marketplace_endpoint = add_query_arg( array(
+					if ( false === $marketplace ) {
+						$args = array(
+							// brand defaults to plugin id
 							'brand' => container()->plugin()->id,
 							'per_page' => 36,
-						), NFD_HIIVE_URL . '/marketplace/v1/products' );
+						);
+						// if brand and region are set on container, use those for brand
+						if ( container()->brand && container()->region ) {
+							$args['brand'] = container()->brand . '_' . container()->region;
+						} 
+						// or if only brand is set on container, use that for brand
+						elseif ( container()->brand ) {
+							$args['brand'] = container()->brand;
+						}
+						// construct endpoint with args
+						$marketplace_endpoint = add_query_arg(
+							$args,
+							NFD_HIIVE_URL . '/marketplace/v1/products'
+						);
 						
 						$response = wp_remote_get(
 							$marketplace_endpoint,


### PR DESCRIPTION
@wpscholar - does this work for MOJO?

After talking this morning I think optionally setting the brand and region in the container will be better than setting it in the component. The API request is on the PHP side of things so I figured we could set the options on the container (where the plugin->id is currently set too) and keep that logic in the same place. Then we don't have to pass them from js to PHP either.

This will use plugin->id but override it with brand _ region or just brand if they are set. Another option would be allowing a single override method and then the logic can live in the plugin rather than the module. I think it can be consistent across them all though so the logic can be consistent, I'm just not sure if there will be special case overrides that we'll want and in that case putting it in the plugins might make more sense.

Thougts?