### PR TITLE
Feature/deep link routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ const moduleMethods = {
     classnames,
     useState,
     useEffect,
+    useNavigate,
+    useLocation
 };
 // constants to pass to module
 const moduleConstants = {
@@ -79,3 +81,10 @@ The only other interactions is the module expects a container from the module lo
 Marketplace will load "Featured" products in the first tab, followed by the remaining categories in alphabetical order.
 
 The Products are each rendered via the MarketplaceItem component. This will pull in the Title, description, formatted_price (localized with proper currency and term detail), thumbnail image (should be 1180x660px or a matching aspect ratio at least), and CTA buttons. The primary button will load as well as an optioonal secondary button. If a CTB id exists (and the component level constant supportCTB allows it) the primary button will tranform into a CTB button which will open the click to buy modal.
+
+
+## Changelog
+
+### Version 1.3
+
+Adds the deep linking provided the plugin is using react-router-dom v6 and passes in the `useNavigate` and `useLocation` methods.

--- a/includes/MarketplaceApi.php
+++ b/includes/MarketplaceApi.php
@@ -34,7 +34,7 @@ class MarketplaceApi {
 
 					if ( false === $marketplace ) {
 						$args = array(
-							'per_page' => 36,
+							'per_page' => 60,
 							// if marketplace brand is set on container, 
 							//  use it as brand override, 
 							//  otherwise use plugin id (default)


### PR DESCRIPTION
Addresses https://jira.newfold.com/browse/PRESS1-54

Allow for deep linking into each category on the marketplace url ( #/marketplace/{category} ).

The category slug is automatically set as a lowercase version of the provided Category (also replacing spaces with dashes - even though there are currently no categories with spaces)

If a marketplace loads with a path that does not match any category, load the featured tab.

When tabs are clicked, update the url.

Also, load 60 products to account for more products being added.