### PR TITLE
Feature/add category endpoint

### DIFF
--- a/includes/MarketplaceApi.php
+++ b/includes/MarketplaceApi.php
@@ -13,12 +13,12 @@ use function NewfoldLabs\WP\ModuleLoader\container;
 class MarketplaceApi {
 
 	/**
-	 * Transient name where notifications are stored.
+	 * Transient name where marketplace data is stored.
 	 */
 	const TRANSIENT = 'newfold_marketplace';
 
 	/**
-	 * Register notification routes.
+	 * Register marketplace routes.
 	 */
 	public static function registerRoutes() {
 
@@ -28,51 +28,7 @@ class MarketplaceApi {
 			'/marketplace',
 			array(
 				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => function ( \WP_REST_Request $request ) {
-					
-					$marketplace = get_transient( self::TRANSIENT );
-
-					if ( false === $marketplace ) {
-						$args = array(
-							'per_page' => 60,
-							// if marketplace brand is set on container, 
-							//  use it as brand override, 
-							//  otherwise use plugin id (default)
-							'brand'    => container()->has('marketplace_brand') ?
-											container()->get('marketplace_brand') :
-											container()->plugin()->id,
-						);
-
-						// construct endpoint with args
-						$marketplace_endpoint = add_query_arg(
-							$args,
-							NFD_HIIVE_URL . '/marketplace/v1/products'
-						);
-						
-						$response = wp_remote_get(
-							$marketplace_endpoint,
-							array(
-								'headers' => array(
-									'Content-Type'  => 'application/json',
-									'Accept'        => 'application/json',
-									'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(),
-								),
-							)
-						);
-							
-						// return rest_ensure_response( $response );
-						if ( ! is_wp_error( $response ) ) {
-							$body = wp_remote_retrieve_body( $response );
-							$data = json_decode( $body, true );
-							if ( $data && is_array( $data ) ) {
-								$marketplace = $data;
-								$expiration = array_key_exists( 'ttl', $marketplace ) ? $marketplace['ttl'] : DAY_IN_SECONDS;
-								self::setTransient( $marketplace, $expiration );
-							}
-						}
-					}
-					return $marketplace;
-				},
+				'callback' => __CLASS__ . '::marketplace_callback',
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
@@ -91,4 +47,113 @@ class MarketplaceApi {
 		set_transient( self::TRANSIENT, $data, $expiration );
 	}
 
+	/**
+	 * Get expiration from response
+	 */
+	public static function get_expiration( $marketplace ) {
+		// get response['meta']['ttl'] if it exists, otherwise set to default 24hrs
+		return array_key_exists( 'meta', $marketplace ) &&
+			array_key_exists( 'ttl', $marketplace['meta'] ) ?
+			$marketplace['meta']['ttl'] :
+			DAY_IN_SECONDS;
+
+	}
+
+	/**
+	 * Get marketplace data
+	 */
+	public static function marketplace_callback( \WP_REST_Request $request ) {
+					
+		$marketplace = get_transient( self::TRANSIENT );
+
+		if ( false === $marketplace ) {
+
+			$args = array(
+				'per_page' => 60,
+				// if marketplace brand is set on container, 
+				//  use it as brand override, 
+				//  otherwise use plugin id (default)
+				'brand'    => container()->has('marketplace_brand') ?
+								container()->get('marketplace_brand') :
+								container()->plugin()->id,
+			);
+
+			$products = self::product_data( $args );
+			$categories = self::category_data( $args );
+
+			$marketplace['categories'] = $categories;
+			$marketplace['products'] = $products;
+
+			$expiration = self::get_expiration( $products );
+			self::setTransient( json_encode($marketplace), $expiration );
+			
+		}
+		return $marketplace;
+	}
+
+	/**
+	 * Get product data from products endpoint
+	 * 
+	 * @param Array $args
+	 */
+	public static function product_data( $args ){
+		// construct endpoint with args
+		$marketplace_endpoint = add_query_arg(
+			$args,
+			NFD_HIIVE_URL . '/marketplace/v1/products'
+		);
+		
+		$response = wp_remote_get(
+			$marketplace_endpoint,
+			array(
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Accept'        => 'application/json',
+					// 'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(), // not needed since it's a publicly accessible endpoint
+				),
+			)
+		);
+			
+		// return rest_ensure_response( $response );
+		if ( ! is_wp_error( $response ) ) {
+			$body = wp_remote_retrieve_body( $response );
+			$data = json_decode( $body, true );
+			if ( $data && is_array( $data ) ) {
+				return $data;
+			}
+		}
+	}
+
+	/**
+	 * Get category data from categories endpoint
+	 * 
+	 * @param Array $args
+	 */
+	public static function category_data( $args ){
+		// construct endpoint with args
+		$category_endpoint = add_query_arg(
+			$args,
+			NFD_HIIVE_URL . '/marketplace/v1/products/categories'
+		);
+		
+		$response = wp_remote_get(
+			$category_endpoint,
+			array(
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Accept'        => 'application/json',
+					// 'Authorization' => 'Bearer ' . HiiveConnection::get_auth_token(), // not needed since it's a publicly accessible endpoint
+				),
+			)
+		);
+			
+		// return rest_ensure_response( $response );
+		if ( ! is_wp_error( $response ) ) {
+			$body = wp_remote_retrieve_body( $response );
+			$data = json_decode( $body, true );
+			if ( $data && is_array( $data ) ) {
+				return $data;
+			}
+		}
+	}
 }

--- a/includes/MarketplaceApi.php
+++ b/includes/MarketplaceApi.php
@@ -66,7 +66,8 @@ class MarketplaceApi {
 							$data = json_decode( $body, true );
 							if ( $data && is_array( $data ) ) {
 								$marketplace = $data;
-								self::setTransient( $marketplace );
+								$expiration = array_key_exists( 'ttl', $marketplace ) ? $marketplace['ttl'] : DAY_IN_SECONDS;
+								self::setTransient( $marketplace, $expiration );
 							}
 						}
 					}


### PR DESCRIPTION
Load the category endpoint along with the products endpoint and store the data in the same transient but now json-ified. The transient now also properly expires with the provided TTL via endpoint meta value.

Removes hard-coded `featured` category sticky sorting and uses priority sorting from endpoint.