### PR TITLE
always return the marketplace as json

### DIFF
--- a/includes/MarketplaceApi.php
+++ b/includes/MarketplaceApi.php
@@ -81,12 +81,16 @@ class MarketplaceApi {
 			$products = self::product_data( $args );
 			$categories = self::category_data( $args );
 
-			$marketplace['categories'] = $categories;
-			$marketplace['products'] = $products;
-
-			$expiration = self::get_expiration( $products );
-			self::setTransient( json_encode($marketplace), $expiration );
-			
+			if ( $products && $categories ) {
+				$marketplace = json_encode(
+					array(
+						'categories' => $categories,
+						'products'   => $products
+				 	)
+				);
+				$expiration = self::get_expiration( $products );
+				self::setTransient( $marketplace, $expiration );
+			}
 		}
 		return $marketplace;
 	}


### PR DESCRIPTION
The marketplace value was returned as an array but saved to the transient as json data. So if there was no transient, the marketplace data format was incorrect. This makes the marketplace callback always return data as json so the component can reliably consume data.