### PR TITLE
Fix/marketplace callback as json

### DIFF
--- a/components/marketplace/index.js
+++ b/components/marketplace/index.js
@@ -32,13 +32,12 @@ import { default as MarketplaceIsLoading } from '../marketplaceIsLoading/';
 		methods.apiFetch( {
 			url: `${constants.resturl}/newfold-marketplace/v1/marketplace`
 		}).then( ( response ) => {
-			let json = JSON.parse(response);
 			// check response for data
-			if ( ! json.hasOwnProperty('categories') || ! json.hasOwnProperty('products') ) {
+			if ( ! response.hasOwnProperty('categories') || ! response.hasOwnProperty('products') ) {
 				setIsError( true );
 			} else {
-				setMarketplaceItems( json.products.data );
-				setMarketplaceCategories( validateCategories(json.categories.data) );
+				setMarketplaceItems( response.products.data );
+				setMarketplaceCategories( validateCategories(response.categories.data) );
 			}
 		});
 	}, [] );

--- a/includes/MarketplaceApi.php
+++ b/includes/MarketplaceApi.php
@@ -92,7 +92,7 @@ class MarketplaceApi {
 				self::setTransient( $marketplace, $expiration );
 			}
 		}
-		return $marketplace;
+		return rest_ensure_response( json_decode( $marketplace ) );
 	}
 
 	/**

--- a/includes/MarketplaceApi.php
+++ b/includes/MarketplaceApi.php
@@ -81,12 +81,16 @@ class MarketplaceApi {
 			$products = self::product_data( $args );
 			$categories = self::category_data( $args );
 
-			$marketplace['categories'] = $categories;
-			$marketplace['products'] = $products;
-
-			$expiration = self::get_expiration( $products );
-			self::setTransient( json_encode($marketplace), $expiration );
-			
+			if ( $products && $categories ) {
+				$marketplace = json_encode(
+					array(
+						'categories' => $categories,
+						'products'   => $products
+				 	)
+				);
+				$expiration = self::get_expiration( $products );
+				self::setTransient( $marketplace, $expiration );
+			}
 		}
 		return $marketplace;
 	}


### PR DESCRIPTION
This uses `json_decode` in php to decode the response to json rather than sending as a string and using js JSON.parse in the component. 

This lets the test fixture function properly and passes data reliably as json too.