### PR TITLE
Independent rest root property

### DIFF
--- a/includes/PluginsMarketplace.php
+++ b/includes/PluginsMarketplace.php
@@ -106,6 +106,7 @@ class PluginsMarketplace {
 			'nfd_plugins_marketplace_js',
 			'nfdPremiumPluginsMarketplace',
 			array(
+				'restApiRoot'			 => \get_home_url() . '/index.php?rest_route=',			
 				'restApiNonce'           => wp_create_nonce( 'wp_rest' ),
 				'marketplaceDescription' => __( 'Unlock the full potential of your WordPress website with premium plugins from', 'newfold-marketplace-module' ) . ' ' . ucwords( container()->plugin()->id ),
 			)

--- a/includes/PluginsMarketplace.php
+++ b/includes/PluginsMarketplace.php
@@ -106,7 +106,7 @@ class PluginsMarketplace {
 			'nfd_plugins_marketplace_js',
 			'nfdPremiumPluginsMarketplace',
 			array(
-				'restApiRoot'            => \get_home_url() . '/index.php?rest_route=',	
+				'restApiRoot'            => \get_home_url() . '/index.php?rest_route=',
 				'restApiNonce'           => wp_create_nonce( 'wp_rest' ),
 				'marketplaceDescription' => __( 'Unlock the full potential of your WordPress website with premium plugins from', 'newfold-marketplace-module' ) . ' ' . ucwords( container()->plugin()->id ),
 			)

--- a/includes/PluginsMarketplace.php
+++ b/includes/PluginsMarketplace.php
@@ -106,7 +106,7 @@ class PluginsMarketplace {
 			'nfd_plugins_marketplace_js',
 			'nfdPremiumPluginsMarketplace',
 			array(
-				'restApiRoot'			 => \get_home_url() . '/index.php?rest_route=',			
+				'restApiRoot'            => \get_home_url() . '/index.php?rest_route=',	
 				'restApiNonce'           => wp_create_nonce( 'wp_rest' ),
 				'marketplaceDescription' => __( 'Unlock the full potential of your WordPress website with premium plugins from', 'newfold-marketplace-module' ) . ' ' . ucwords( container()->plugin()->id ),
 			)

--- a/includes/assets/js/NFDPluginsMarketplace.js
+++ b/includes/assets/js/NFDPluginsMarketplace.js
@@ -9,7 +9,7 @@ class NFDPluginsMarketplace {
         })
 
         // Fetch data from the Marketplace API
-        fetch(window.nfdRestRoot + '/newfold-marketplace/v1/marketplace', {
+        fetch(nfdPremiumPluginsMarketplace.restApiRoot + '/newfold-marketplace/v1/marketplace', {
             credentials: 'same-origin',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
Move away from using "window.nfdRestRoot" to the module-created object since "window.nfdRestRoot" is not supported on all brand plugins.