### PR TITLE
add marketplaceLite component for a subset of products to be loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The module also contains some javascript components that are used together withi
 1. Marketplace - the main component, this one gets loaded into the plugin app with some props and loads the rest.
 2. MarketplaceList - this loads the contents of the TabPanel, basically a collection of marketplace items.
 3. MarketplaceItem - This is used to render each item in the list.
+4. MarketplaceLite - this is a simpler main component, it displays a single category/vendor of products and removes tab navigation.
 
 The main Marketplace component expects 3 props with others nested within. This is so the module can be very light and not have complex dependencies. The plugin app, will have these components and methods in place and must pass them to the component as follows:
 ```javascript
@@ -82,13 +83,14 @@ Marketplace will load "Featured" products in the first tab, followed by the rema
 
 The Products are each rendered via the MarketplaceItem component. This will pull in the Title, description, formatted_price (localized with proper currency and term detail), thumbnail image (should be 1180x660px or a matching aspect ratio at least), and CTA buttons. The primary button will load as well as an optioonal secondary button. If a CTB id exists (and the component level constant supportCTB allows it) the primary button will tranform into a CTB button which will open the click to buy modal.
 
+### Premium Plugins
+This module adds plugin marketplace products to a "Premium Plugins" tab and subnavigation link in the WordPress plugin section. To disable this feature use the `nfd_enable_plugins_marketplace` filter and return `false` in the plugin like so:
+```
+add_filter( 'nfd_enable_plugins_marketplace', '__return_false' );
+```
 
 ## Changelog
 
-### Version 1.3
+See the releases for the changelog and version details. 
 
-Adds the deep linking provided the plugin is using react-router-dom v6 and passes in the `useNavigate` and `useLocation` methods.
-
-### Version 1.4
-
-Adds category endpoint and category priority sorting to the marketplace data stored in the transient.
+https://github.com/newfold-labs/wp-module-marketplace/releases

--- a/components/marketplaceLite/index.js
+++ b/components/marketplaceLite/index.js
@@ -1,0 +1,178 @@
+import { default as MarketplaceIsLoading } from '../marketplaceIsLoading/';
+import { default as MarketplaceItem } from '../marketplaceItem/';
+
+/**
+ * Marketplace Module
+ * For use in brand app to display marketplace products filtered by category and/or vendor values.
+ * This is a lite version of the marketplace, in that it doesn't display full list of products or
+ * navigation, it is only a list of speficied products.
+ * 
+ * @param {*} props 
+ * @returns 
+ */
+ const MarketplaceLite = ({methods, constants, Components, ...props}) => {
+	const [ isLoading, setIsLoading ] = methods.useState( true );
+	const [ isError, setIsError ] = methods.useState( false );
+	const [ marketplaceCategories, setMarketplaceCategories ] = methods.useState( [] );
+	const [ marketplaceItems, setMarketplaceItems ] = methods.useState( [] );
+	const limit = constants.perPage ? constants.perPage : 12;
+	/**
+	 * on mount load all marketplace data from module api
+	 */
+	methods.useEffect(() => {
+		methods.apiFetch( {
+			url: `${constants.resturl}/newfold-marketplace/v1/marketplace`
+		}).then( ( response ) => {
+			// check response for data
+			if ( ! response.hasOwnProperty('categories') || ! response.hasOwnProperty('products') ) {
+				setIsError( true );
+			} else {
+				setMarketplaceItems( validateProducts( response.products.data, props.vendor ) );
+				setMarketplaceCategories( validateCategories( response.categories.data ) );
+			}
+		});
+	}, [] );
+
+	/**
+	 * When marketplaceItems changes
+	 * verify that there are products
+	 */
+	 methods.useEffect(() => {
+		// only after a response
+		if ( !isLoading ) {
+			// if no marketplace items, display error
+			if ( marketplaceItems.length < 1 ) {
+				setIsError( true );
+			} else {
+				setIsError( false );
+			}
+		}
+	}, [ marketplaceItems ] );
+
+	/**
+	 * When marketplaceCategories changes
+	 * verify that the tab is a category
+	 */
+	methods.useEffect(() => {
+		// only before rendered, but after categories are populated
+		if ( isLoading && marketplaceCategories.length >= 1 ) {
+			// read initial tab from path
+			setIsLoading( false );
+		}
+	}, [ marketplaceCategories ] );
+
+	/**
+	 * Validate provided category data
+	 * @param Array categories 
+	 * @returns 
+	 */
+	const validateProducts = ( products, vendor ) => {
+		
+		if ( vendor ) {
+			return setProductListCount( filterProductsByVendor(products, vendor), limit );
+		} else {
+			return setProductListCount( products, limit )
+		}
+	};
+
+	/**
+	 * Set Product List Length - this controls how many products are displayed in the list, it gets us active current items
+	 * @param Array items 
+	 * @param Number itemsCount 
+	 * @returns 
+	 */
+	const setProductListCount = (items, itemsCount) => {
+		let count = 0;
+		return items.filter((item) => {
+			count++;
+			return count <= itemsCount;
+		});
+	};
+
+	/**
+	 * Filter Products By Vendor - this ensures only this vendor's products are listed
+	 * @param Array items - the products
+	 * @param string vendor - the vendor to filter by 
+	 * @returns 
+	 */
+	const filterProductsByVendor = (items, vendorname) => {
+		return items.filter((item) => {
+			return item.vendor !== null && item.vendor.name === vendorname;
+		});
+	};
+
+	/**
+	 * Validate provided category data
+	 * @param Array categories 
+	 * @returns 
+	 */
+	const validateCategories = ( categories ) => {
+		
+		if ( ! categories.length ) {
+			return [];
+		}
+		
+		let thecategories = [];
+		categories.forEach((cat)=>{
+			cat.className = 'newfold-marketplace-tab-'+cat.name;
+
+			if ( cat.products_count > 0 &&
+				( 
+					cat.title === props.category ||
+					cat.name === props.category 
+				)
+			) {
+				thecategories.push(cat);
+			}
+		});
+		
+		return thecategories;
+	};
+
+	/**
+	 * render marketplace preloader
+	 * 
+	 * @returns React Component
+	 */
+	 const renderSkeleton = () => {
+		// render skeleton with no tabs and set the number from received perPage prop
+		return <MarketplaceIsLoading 
+			filter={false}
+			items={limit}
+		/>;
+	}
+
+
+	return (
+		<div className={methods.classnames('newfold-marketplace-wrapper newfold-marketplaceLite-wrapper')}>
+			{ isLoading && 
+				renderSkeleton()
+			}
+			{ isError && 
+				<h3>Oops, there was an error loading products, please try again later.</h3>
+			}
+			{ !isLoading && !isError &&
+				<div className={ `marketplace-lite marketplace-lite-category-${ props.category } marketplace-lite-vendor-${ props.vendor }` }>
+					<div className="grid col2">
+						{ marketplaceItems.length > 0 && marketplaceItems.map((item) => (
+								<MarketplaceItem
+									key={item.hash} 
+									item={item}
+									Components={Components}
+									methods={methods}
+									constants={constants}
+								/>
+							))
+						}
+						{ !marketplaceItems.length &&
+							<p>Sorry, there are no products available. Please, try again later.</p>
+						}
+					</div>
+				</div>
+			}
+		</div>
+	)
+
+};
+
+export default MarketplaceLite;

--- a/includes/PluginsMarketplace.php
+++ b/includes/PluginsMarketplace.php
@@ -14,7 +14,7 @@ class PluginsMarketplace {
 	 * Initialize.
 	 */
 	public static function init() {
-		// Filters wheather the premuim plugins tab is enabled or disabled. Default is enabled.
+		// Filters whether the premuim plugins tab is enabled or disabled. Default is enabled.
 		$enabled = apply_filters( 'nfd_enable_plugins_marketplace', true );
 
 		if ( $enabled ) {


### PR DESCRIPTION
Add a new component that is a more streamlined version of the marketplace. It allows filtering products to a single category and/or vendor.

The use case for this is the ecommerce module wanting to display YITH eCommerce products in the store setup. The POC for that can be found here: 
- https://github.com/newfold-labs/wp-module-ecommerce/pull/51/
- https://github.com/bluehost/bluehost-wordpress-plugin/pull/322/

With this new module, I propose the plugin can load the component from the marketplace module and pass it to the ecommerce module. See the WIP PR using this component as an example: https://github.com/bluehost/bluehost-wordpress-plugin/pull/331/