### PR TITLE
Refreshed UI

### DIFF
--- a/components/marketplace/index.js
+++ b/components/marketplace/index.js
@@ -22,7 +22,7 @@ import { default as MarketplaceIsLoading } from '../marketplaceIsLoading/';
 	 */
 	methods.useEffect(() => {
 		methods.apiFetch( {
-			url: methods.NewfoldRuntime.createApiUrl( `/newfold-marketplace/v1/marketplace` )
+			url: methods.NewfoldRuntime.createApiUrl( '/newfold-marketplace/v1/marketplace' )
 		}).then( ( response ) => {
 			// check response for data
 			if ( ! response.hasOwnProperty('categories') || ! response.hasOwnProperty('products') ) {

--- a/components/marketplaceItem/index.js
+++ b/components/marketplaceItem/index.js
@@ -24,7 +24,7 @@ import { ArrowRightIcon } from "@heroicons/react/24/outline";
 		event.data = event.data || {};
 		event.data.page = window.location.href;
 		methods.apiFetch({
-			url: `${constants.resturl}${constants.eventendpoint}`,
+			url: methods.NewfoldRuntime.createApiUrl( constants.eventendpoint ),
 			method: 'POST', 
 			data: event
 		});

--- a/components/marketplaceItem/index.js
+++ b/components/marketplaceItem/index.js
@@ -1,3 +1,11 @@
+import { 
+    Button,
+    Card,
+    Link,
+    Title
+} from "@newfold/ui-component-library";
+import { ArrowRightIcon } from "@heroicons/react/24/outline";
+
 /**
  * MarketplaceItem Component
  * For use in Marketplace to display marketplace items
@@ -5,7 +13,7 @@
  * @param {*} props 
  * @returns 
  */
- const MarketplaceItem = ({ item, Components, methods, constants }) => {
+ const MarketplaceItem = ({ item, methods, constants }) => {
 
 	/**
 	 * Send events to the WP REST API
@@ -120,7 +128,7 @@
 		let primaryCTA, secondaryCTA;
 		if ( item.primaryUrl && item.primaryCallToAction ) {
 			primaryCTA = (
-				<Components.Button
+				<Button
 					variant="primary"
 					className="primary-cta"
 					target="_blank"
@@ -133,20 +141,20 @@
 					}
 				>
 					{ item.primaryCallToAction }
-				</Components.Button>
+				</Button>
 			);
 		}
 
 		if ( item.secondaryCallToAction && item.secondaryUrl ) {
 			secondaryCTA = (
-				<Components.Button 
+				<Button 
 					variant="secondary"
 					className="secondary-cta"
 					target="_blank"
 					href={ item.secondaryUrl }
 				>
 					{ item.secondaryCallToAction }
-				</Components.Button>
+				</Button>
 			);
 		}
 		return( 
@@ -157,54 +165,84 @@
 		);
 	};
 
+	const renderPrimaryCTA = (item) => {
+		let primaryCTA = '';
+
+		if ( item.primaryCallToAction && item.primaryUrl ) {
+			if (constants.supportsCTB && item.clickToBuyId) {
+				primaryCTA = (
+					<Button
+						as="a"
+						href={item.primaryUrl}
+						target="_blank"
+						data-action="load-nfd-ctb"
+						data-ctb-id={item.clickToBuyId}
+					>
+						{item.primaryCallToAction}
+					</Button>
+				);
+			} else {
+				primaryCTA = (
+					<Button
+						as="a"
+						href={item.primaryUrl}
+						target="_blank"
+					>
+						{item.primaryCallToAction}
+					</Button>
+				);
+			}
+		}
+
+		return ( primaryCTA );
+    };
+
 	const renderPrice = (item) => {
-		let pricewrap, price, fullprice;
+		let pricewrap, price, fullprice = '';
 		if ( item.price > 0 && item.price_formatted ) {
 			price =  (
-				<div className="price">{ item.price_formatted }</div>
+				<span className="marketplace-item-price nfd-bg-[#E2E8F0] nfd-py-1 nfd-px-3 nfd-rounded-full">{ item.price_formatted }</span>
 			);
 			if ( item.full_price > 0 && item.full_price_formatted ) {
 				fullprice =  (
-					<s className="price full-price">{ item.full_price_formatted }</s>
-				);	
-				pricewrap = (
-					<div className="price-wrap has-full-price">
-						{ fullprice }
-						{ price }
-					</div>
-				);
-			} else {
-				pricewrap = (
-					<div className="price-wrap">
-						{ price }
-					</div>
+					<span className="marketplace-item-fullprice nfd-line-through">{ item.full_price_formatted }</span>
 				);
 			}
+			pricewrap = (
+				<div className="marketplace-item-price-wrap has-full-price nfd-flex nfd-flex-col nfd-items-center nfd-gap-2 nfd-text-[#1E293B] nfd-font-medium">
+					{ fullprice }
+					{ price }
+				</div>
+			);
 		}
 		return pricewrap;
 	};
 
 	return (
-		<Components.Card className={ `marketplace-item marketplace-item-${ item.id } ${ item.full_price ? "product-has-full-price" : ""}` } id={`marketplace-item-${ item.id }`}>
+		<Card className={ `marketplace-item marketplace-item-${ item.id } ${ item.full_price ? "product-has-full-price" : ""}` } id={`marketplace-item-${ item.id }`}>
+			<Card.Header className="nfd-h-auto nfd-p-0">
 			{ item.productThumbnailUrl && (
-				<Components.CardMedia>
-					<img src={ item.productThumbnailUrl } alt={ item.name + ' thumbnail' } />
-				</Components.CardMedia>
+                <img src={item.productThumbnailUrl} alt={item.name + ' thumbnail'} className="nfd-w-full nfd-aspect-video marketplace-item-image" />
 			) }
-			<Components.CardHeader>
-				<h2>{ item.name }</h2>
+			</Card.Header>
+			<Card.Content className="nfd-flex nfd-flex-col nfd-gap-3">
+				<Title as="h3" size="4" className="marketplace-item-title">
+					{item.name}
+				</Title>
+				<p>{item.description}</p>
+
+				{item.secondaryCallToAction &&
+                    <Link as="a" href={item.secondaryUrl} target="_blank" className="nfd-inline-flex nfd-items-center nfd-gap-1.5 nfd-w-max nfd-no-underline">
+                        <span className="nfd-text-primary">{item.secondaryCallToAction}</span>
+                        <ArrowRightIcon className="nfd-text-[#18181B] nfd-w-3" />
+                    </Link>
+                }
+			</Card.Content>
+			<Card.Footer className="nfd-flex nfd-justify-between nfd-items-center nfd-flex-wrap nfd-gap-2 marketplace-item-footer">
 				{ renderPrice(item) }
-			</Components.CardHeader>
-			{ item.description && 
-				<Components.CardBody 
-					// Comes from internal source - let's trust ourselves (for now)
-					dangerouslySetInnerHTML={{ __html: item.description }} 
-				/>
-			}
-			<Components.CardFooter>
-				{ renderCTAs(item) }
-			</Components.CardFooter>
-		</Components.Card>
+				{ renderPrimaryCTA(item) }
+			</Card.Footer>
+		</Card>
 	);
 };
 

--- a/components/marketplaceList/index.js
+++ b/components/marketplaceList/index.js
@@ -1,5 +1,6 @@
 
 import { default as MarketplaceItem } from '../marketplaceItem/';
+import { Button, Title } from "@newfold/ui-component-library";
 
 /**
  * MarketplaceList Component
@@ -8,7 +9,7 @@ import { default as MarketplaceItem } from '../marketplaceItem/';
  * @param {*} props 
  * @returns 
  */
-const MarketplaceList = ({ marketplaceItems, currentCount, category, Components, methods, constants, saveCategoryDisplayCount }) => {
+const MarketplaceList = ({ marketplaceItems, currentCount, category, methods, constants }) => {
 	const [ itemsCount, setItemsCount ] = methods.useState( currentCount );
 	const [ currentItems, setCurrentItems ] = methods.useState( [] );
 	const [ activeItems, setActiveItems ] = methods.useState( [] )
@@ -51,7 +52,7 @@ const MarketplaceList = ({ marketplaceItems, currentCount, category, Components,
 	 */
 	methods.useEffect(() => {
 		setCurrentItems( filterProductsByCategory(marketplaceItems, category) );
-	}, []);
+	}, [ marketplaceItems ]);
 
 	/**
 	 * recalculate activeItems if currentItems or itemsCount changes
@@ -64,40 +65,42 @@ const MarketplaceList = ({ marketplaceItems, currentCount, category, Components,
 	 * pass up itemsCount for this list when it changes
 	 * this is so users don't need to load more every time they click back into a category
 	 */
-	methods.useEffect(() => {
-		saveCategoryDisplayCount( category.name, itemsCount );
-	}, [ itemsCount ] );
+	// methods.useEffect(() => {
+	// 	saveCategoryDisplayCount( category.name, itemsCount );
+	// }, [ itemsCount ] );
 
 	return (
-		<div className={ `marketplace-list marketplace-list-${ category.name }` }>
-			<div className="grid col2">
+		<>
+			<Title as="h2" size="3" className="marketplace-category-title nfd-text-2xl nfd-font-medium nfd-text-title nfd-pb-6">
+				{category.title}
+			</Title>
+			<div className={ `marketplace-list marketplace-list-${ category.name } wppbh-app-marketplace-list nfd-grid nfd-gap-6 nfd-grid-cols-1 min-[1120px]:nfd-grid-cols-2 min-[1400px]:nfd-grid-cols-3` }>
 				{ activeItems.length > 0 && activeItems.map((item) => (
-						<MarketplaceItem
-							key={item.hash} 
-							item={item}
-							Components={Components}
-							methods={methods}
-							constants={constants}
-						/>
+					<MarketplaceItem
+						key={item.id} 
+						item={item}
+						methods={methods}
+						constants={constants}
+					/>
 					))
 				}
 				{ !activeItems.length &&
 					<p>Sorry, no marketplace items. Please, try again later.</p>
 				}
+				{ currentItems && currentItems.length > itemsCount &&
+					<div style={{ display: 'flex', margin: '1rem 0'}}>
+						<Button
+							onClick={loadMoreClick}
+							variant="primary" 
+							className="align-center"
+							style={{margin: 'auto'}}
+							>
+							Load More
+						</Button>
+					</div>
+				}
 			</div>
-			{ currentItems && currentItems.length > itemsCount &&
-				<div style={{ display: 'flex', margin: '1rem 0'}}>
-					<Components.Button
-						onClick={loadMoreClick}
-						variant="primary" 
-						className="align-center"
-						style={{margin: 'auto'}}
-					>
-						Load More
-					</Components.Button>
-				</div>
-			}
-		</div>
+		</>
 	)
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,437 @@
+{
+  "name": "@newfold-labs/wp-module-marketplace",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@newfold-labs/wp-module-marketplace",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@heroicons/react": "^2.0.18",
+        "@newfold/ui-component-library": "^0.1.1-3"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.17",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.17.tgz",
+      "integrity": "sha512-4am+tzvkqDSSgiwrsEpGWqgGo9dz8qU5M3znCkC4PgkpY4HcCZzEDEvozltGGGHIKl9jbXbZPSH5TWn4sWJdow==",
+      "dependencies": {
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.18.tgz",
+      "integrity": "sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==",
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
+    "node_modules/@newfold/ui-component-library": {
+      "version": "0.1.1-3",
+      "resolved": "https://registry.npmjs.org/@newfold/ui-component-library/-/ui-component-library-0.1.1-3.tgz",
+      "integrity": "sha512-nUcNiqeNjqzdsfXaPLCcmEQW87MF3OukiNqeaYdBh+D87U5WJ/Ib0gBOiemQ1mPSjFL8EC2QzUV78C7vOm5jnw==",
+      "dependencies": {
+        "@headlessui/react": "^1.7.8",
+        "@heroicons/react": "^1.0.6",
+        "classnames": "^2.3.2",
+        "lodash": "^4.17.21",
+        "postcss-import": "^15.1.0",
+        "prop-types": "^15.8.1",
+        "react-animate-height": "^3.1.0",
+        "react-error-boundary": "^3.1.4"
+      },
+      "peerDependencies": {
+        "@wordpress/element": "^4.1.1"
+      }
+    },
+    "node_modules/@newfold/ui-component-library/node_modules/@heroicons/react": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.6.tgz",
+      "integrity": "sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==",
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/react-animate-height": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.2.tgz",
+      "integrity": "sha512-uUOS+RhYVgyJEWcuAJgelVwhcJ2chsMk7HZCpu+wtjSlFAGSFsHU0r4lMTt47HQ1RdQfI5MmFRt43yHTP9lfmQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+    },
+    "node_modules/resolve": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  },
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
+    },
+    "@headlessui/react": {
+      "version": "1.7.17",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.17.tgz",
+      "integrity": "sha512-4am+tzvkqDSSgiwrsEpGWqgGo9dz8qU5M3znCkC4PgkpY4HcCZzEDEvozltGGGHIKl9jbXbZPSH5TWn4sWJdow==",
+      "requires": {
+        "client-only": "^0.0.1"
+      }
+    },
+    "@heroicons/react": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.18.tgz",
+      "integrity": "sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw=="
+    },
+    "@newfold/ui-component-library": {
+      "version": "0.1.1-3",
+      "resolved": "https://registry.npmjs.org/@newfold/ui-component-library/-/ui-component-library-0.1.1-3.tgz",
+      "integrity": "sha512-nUcNiqeNjqzdsfXaPLCcmEQW87MF3OukiNqeaYdBh+D87U5WJ/Ib0gBOiemQ1mPSjFL8EC2QzUV78C7vOm5jnw==",
+      "requires": {
+        "@headlessui/react": "^1.7.8",
+        "@heroicons/react": "^1.0.6",
+        "classnames": "^2.3.2",
+        "lodash": "^4.17.21",
+        "postcss-import": "^15.1.0",
+        "prop-types": "^15.8.1",
+        "react-animate-height": "^3.1.0",
+        "react-error-boundary": "^3.1.4"
+      },
+      "dependencies": {
+        "@heroicons/react": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.6.tgz",
+          "integrity": "sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ=="
+        }
+      }
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "is-core-module": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
+    },
+    "postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "requires": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "react-animate-height": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.2.tgz",
+      "integrity": "sha512-uUOS+RhYVgyJEWcuAJgelVwhcJ2chsMk7HZCpu+wtjSlFAGSFsHU0r4lMTt47HQ1RdQfI5MmFRt43yHTP9lfmQ=="
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "requires": {
+        "pify": "^2.3.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+    },
+    "resolve": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "requires": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,15 @@
   "description": "A module for rendering product data and interacting with the Hiive marketplace API.",
   "license": "GPL-2.0-or-later",
   "private": true,
-  "author": {
-    "name": "Micah Wood",
-    "email": "micah@wpscholar.com"
+  "contributors": [
+    "Abdulrahman Al Ani (https://alani.dev/)",
+    "Evan Mullins (https://evanmullins.com)",
+    "Jonathan Desrosiers (https://jonathandesrosiers.com)",
+    "Micah Wood (https://wpscholar.com)",
+    "William Earnhardt (https://wearnhardt.com)"
+  ],
+  "dependencies": {
+    "@heroicons/react": "^2.0.18",
+    "@newfold/ui-component-library": "^0.1.1-3"
   }
 }


### PR DESCRIPTION
Update components to reflect the refreshed UI. 

This adds newfold UI library as a dependency (and heroicons). The UI components are loaded in the module components. So we will no longer need to pass UI components to these module components. They are loaded up at the plugin build and the components are linked properly without a module-level build step (or package) being required.

In the future, I think we can create an app in the module which would load the components and we can do component testing in that environment. This module-level app would be ignored by the plugin, which only loads components from the module as needed.

There is still some cleanup but this gets us to functional parity with what is currently live in the bh plugin. A few things still need verifying:
- Tests were previously updated to reflect this new UI, so they should still pass, but might need some tweaking. 
- We should also add some tests for any functionality that is missing (like the sale pricing display, load more button, the category styles, events)
- Test loading states: skeleton and error states should be verified and we should have tests for each too.

For parity to previous module code, however we still need to:
- test the styles for category-based custom styles (like what we did for Black Friday).
- expose some component to the sidebar navigation so the marketplace categories are loaded via the module (currently they are just hard-coded, which is fine, but requires a plugin release for things like adding a Black Friday category and handling marketplace translations for hg regions).
- test that marketplaceItem events are properly sent.
- test that the marketplaceLite component still functions as expected, though I'm not sure if it's being used (it was built for the e-commerce module to import).