### PR TITLE
fix marketplace tests now that per page/load more limits are in place

### DIFF
--- a/tests/cypress/integration/marketplace.cy.js
+++ b/tests/cypress/integration/marketplace.cy.js
@@ -80,7 +80,7 @@ describe('Marketplace Page', function () {
 	it('Category Tab Filters properly', () => {
 		
 		cy.get( appClass + '-app-subnavitem-Services').click();
-		cy.get('.marketplace-item').should('have.length', 14);
+		cy.get('.marketplace-item').should('have.length', 12);
 		cy.get('#marketplace-item-1fc92f8a-bb9f-47c8-9808-aab9c82d6bf2 h3')
 			.scrollIntoView()
 			.should('be.visible')
@@ -94,7 +94,7 @@ describe('Marketplace Page', function () {
 			.should('have.text', 'Yoast Premium');
 	});
 
-	it.skip('Load more button loads more products', () => {
+	it('Load more button loads more products', () => {
 		cy.get( appClass + '-app-subnavitem-Services').click();
 		cy.wait(300);
 

--- a/tests/cypress/integration/marketplace.cy.js
+++ b/tests/cypress/integration/marketplace.cy.js
@@ -132,4 +132,9 @@ describe('Marketplace Page', function () {
 		});
 	});
 
+	// TEST NEEDED
+	// Product with a sale price displays properly - full_price_formatted
+	// Custom style for a category is in place - categories.data.styles
+	// Product click events fire properly
+
 });


### PR DESCRIPTION
The tests were failing because they weren't expecting the load more button - but now that functionality is back. I updated tests to look for only 12 items (the limit) and even stopped skipping the load more button test.