### PR TITLE
Feature/category subnav helper

### DIFF
--- a/components/marketplace/index.js
+++ b/components/marketplace/index.js
@@ -182,7 +182,10 @@ const defaults = {
 				title={getSectionTitle()}
 				subTitle={constants.text.subTitle}
 			/>
-			<Components.SectionContent className={methods.classnames('newfold-marketplace-wrapper')}>
+			<Components.SectionContent className={methods.classnames(
+				'newfold-marketplace-wrapper',
+				`newfold-marketplace-${marketplaceCategories[activeCategoryIndex]}`
+				)}>
 				{ isLoading && 
 					renderSkeleton()
 				}

--- a/components/marketplaceSubnav/index.js
+++ b/components/marketplaceSubnav/index.js
@@ -1,0 +1,28 @@
+import { NewfoldRuntime } from '@newfold-labs/wp-module-runtime';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Marketplace Subnav Helper Method
+ * 
+ * @returns array of routes
+ */
+export const getMarketplaceSubnavRoutes = () => {
+    return apiFetch( {
+        url: NewfoldRuntime.createApiUrl( '/newfold-marketplace/v1/marketplace' )
+    }).then( ( response ) => {
+        let marketplaceSubnav = [];
+        if ( response.hasOwnProperty('categories') ) {
+            let marketPlaceCategories = response.categories.data;
+            marketPlaceCategories.forEach( (cat) => {
+                // format categories for subnav routes
+                marketplaceSubnav.push(
+                    {
+                        name: '/marketplace/' + cat.name,
+                        title: cat.title
+                    }
+                );
+            });
+        }
+        return marketplaceSubnav;
+    });
+};


### PR DESCRIPTION
This adds a method to get marketplace categories for the plugin navigation as routes. The plugin can load the method when creating routes and let it dynamically populate the categories in the menu.

Here's how the plugin would use such a thing: https://github.com/bluehost/bluehost-wordpress-plugin/commit/b3248044173655f20449cebd65ec7e4a4e66ff0a 

Thoughts?