### PR TITLE
Fix premium plugins test

### DIFF
--- a/tests/cypress/integration/premium-plugins-tab.cy.js
+++ b/tests/cypress/integration/premium-plugins-tab.cy.js
@@ -2,9 +2,12 @@
 const marketplaceProductsFixture = require( '../fixtures/marketplace-products.json' );
 
 describe( 'Plugins Premium Tab', () => {
+
 	before( () => {
 		cy.exec( 'npx wp-env run cli wp transient delete newfold_marketplace' );
+	} );
 
+	beforeEach( () => {
 		cy.intercept(
 			{
 				method: 'GET',
@@ -14,9 +17,9 @@ describe( 'Plugins Premium Tab', () => {
 				body: marketplaceProductsFixture,
 				delay: 1000,
 			}
-		);
+		).as('getMarketplaceProducts');
 		cy.visit( '/wp-admin/plugin-install.php?tab=premium-marketplace' );
-	} );
+	});
 
 	it( 'Premium tab exist', () => {
 		cy.get( '.wrap' )
@@ -34,10 +37,12 @@ describe( 'Plugins Premium Tab', () => {
 	} );
 
 	it( 'Should have products', () => {
+		cy.wait('@getMarketplaceProducts');
 		cy.get( '#the-list' ).children( '.plugin-card' ).should( 'be.visible' );
 	} );
 
 	it( 'Product should display thumbnail', () => {
+		cy.wait('@getMarketplaceProducts');
 		cy.get( '.plugin-card:first-of-type' )
 			.find( '.nfd-plugin-card-thumbnail img' )
 			.scrollIntoView()
@@ -46,6 +51,7 @@ describe( 'Plugins Premium Tab', () => {
 	} );
 
 	it( 'Product should have a name', () => {
+		cy.wait('@getMarketplaceProducts');
 		cy.get( '.plugin-card:first-of-type' )
 			.find( '.nfd-plugin-card-title h3' )
 			.invoke( 'text' )
@@ -53,6 +59,7 @@ describe( 'Plugins Premium Tab', () => {
 	} );
 
 	it( 'Product should have description', () => {
+		cy.wait('@getMarketplaceProducts');
 		cy.get( '.plugin-card:first-of-type' )
 			.find( '.nfd-plugin-card-desc p' )
 			.invoke( 'text' )
@@ -60,6 +67,7 @@ describe( 'Plugins Premium Tab', () => {
 	} );
 
 	it( 'Product should have actions', () => {
+		cy.wait('@getMarketplaceProducts');
 		// primary action
 		cy.get( '.plugin-card:first-of-type' )
 			.find( '.nfd-plugin-card-actions a:first-of-type' )

--- a/tests/cypress/integration/premium-plugins-tab.cy.js
+++ b/tests/cypress/integration/premium-plugins-tab.cy.js
@@ -3,10 +3,6 @@ const marketplaceProductsFixture = require( '../fixtures/marketplace-products.js
 
 describe( 'Plugins Premium Tab', () => {
 
-	before( () => {
-		cy.exec( 'npx wp-env run cli wp transient delete newfold_marketplace' );
-	} );
-
 	beforeEach( () => {
 		cy.intercept(
 			{


### PR DESCRIPTION
The intercept on the `before` only works for the first test. Moving the intercept to `beforeEach` solves this. Also added wait statements to the tests that require the API call.