### PR TITLE
use appId for selector

### DIFF
--- a/components/marketplaceItem/index.js
+++ b/components/marketplaceItem/index.js
@@ -179,7 +179,7 @@ const MarketplaceItem = ( { item, methods, constants } ) => {
 
 		const generateSecondaryUrl = () => {
 			if ( isInternal ) {
-				return `${ window.NewfoldRuntime.admin_url }admin.php?page=bluehost#/marketplace/product/${ item.secondaryUrl }`;
+				return `${ window.NewfoldRuntime.admin_url }admin.php?page=${ window.NewfoldRuntime.plugin.brand }#/marketplace/product/${ item.secondaryUrl }`;
 			}
 
 			return item.secondaryUrl;

--- a/tests/cypress/integration/product-page.cy.js
+++ b/tests/cypress/integration/product-page.cy.js
@@ -1,6 +1,8 @@
 const productPageFixtures = require( '../fixtures/product-page.json' );
 
 describe( 'Product Page', function () {
+	const appClass = '.' + Cypress.env( 'appId' );
+
 	beforeEach( () => {
 		cy.intercept(
 			{
@@ -22,7 +24,8 @@ describe( 'Product Page', function () {
 
 	it( 'Show loading state while fetching', () => {
 		cy.get(
-			'.wppbh-app-marketplace-container div[aria-label="Fetching product details"]'
+			appClass +
+				'-app-marketplace-container div[aria-label="Fetching product details"]'
 		).should( 'be.visible' );
 	} );
 
@@ -45,7 +48,7 @@ describe( 'Product Page', function () {
 			}
 		).as( 'productPageError' );
 		cy.wait( '@productPageError' );
-		cy.get( '.wppbh-app-marketplace-container div[role="alert"]' )
+		cy.get( appClass + '-app-marketplace-container div[role="alert"]' )
 			.find( 'img[alt="Dog walking with a leash"]' )
 			.should( 'exist' )
 			.and( 'be.visible' );


### PR DESCRIPTION
## Proposed changes

Tweak the new product page test to be compatible with other brand plugins using the appId for element selector. The test currently passes for bluehost, but fails for other brand plugins.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
