### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,10 +19,10 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
-    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write      # Required for the reusable workflow to commit translation updates.
       pull-requests: write # Required for the reusable workflow to open or update translation pull requests.
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     timeout-minutes: 30
     with:
       text_domain: 'wp-module-marketplace'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to commit translation updates.
       pull-requests: write # Required for the reusable workflow to open or update translation pull requests.
+    timeout-minutes: 30
     with:
       text_domain: 'wp-module-marketplace'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to commit translation updates.
+      pull-requests: write # Required for the reusable workflow to open or update translation pull requests.
     with:
       text_domain: 'wp-module-marketplace'
     secrets:

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,17 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {} # No checkout or default GITHUB_TOKEN usage in this job.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -30,6 +32,8 @@ jobs:
     name: Bluehost Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone private plugin and module repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -40,6 +44,8 @@ jobs:
     name: Bluehost DEV Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone private plugin and module repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -52,6 +58,8 @@ jobs:
     name: Hostgator Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone private plugin and module repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -32,9 +32,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private plugin and module repositories.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
@@ -45,9 +45,9 @@ jobs:
   bluehost-dev:
     name: Bluehost DEV Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private plugin and module repositories.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
@@ -60,9 +60,9 @@ jobs:
   hostgator:
     name: Hostgator Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private plugin and module repositories.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No checkout or default GITHUB_TOKEN usage in this job.
+    timeout-minutes: 10
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private plugin and module repositories.
+    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private plugin and module repositories.
+    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -60,6 +63,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone private plugin and module repositories.
+    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # No checkout; only reads github.repository in a shell step.
+    timeout-minutes: 10
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to publish coverage (for example to GitHub Pages).
       pull-requests: write # Required for the reusable workflow to post or update pull request coverage feedback.
+    timeout-minutes: 120
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -31,10 +31,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write      # Required for the reusable workflow to publish coverage (for example to GitHub Pages).
       pull-requests: write # Required for the reusable workflow to post or update pull request coverage feedback.
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     timeout-minutes: 120
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # No checkout; only reads github.repository in a shell step.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to publish coverage (for example to GitHub Pages).
+      pull-requests: write # Required for the reusable workflow to post or update pull request coverage feedback.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,13 +8,15 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    permissions:
+      contents: read # Required for actions/checkout in the reusable workflow (Crowdin uses secrets.NEWFOLD_ACCESS_TOKEN as GITHUB_TOKEN).
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -14,9 +14,9 @@ permissions: {}
 
 jobs:
   call-crowdin-workflow:
-    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Required for actions/checkout in the reusable workflow (Crowdin uses secrets.NEWFOLD_ACCESS_TOKEN as GITHUB_TOKEN).
+    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Required for actions/checkout in the reusable workflow (Crowdin uses secrets.NEWFOLD_ACCESS_TOKEN as GITHUB_TOKEN).
+    timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write      # Required so the Crowdin GitHub Action can use GITHUB_TOKEN for repository writes during upload.
       pull-requests: write # Required so the Crowdin GitHub Action can use GITHUB_TOKEN for pull request operations when needed.
+    timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,9 +3,16 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    permissions:
+      contents: write      # Required so the Crowdin GitHub Action can use GITHUB_TOKEN for repository writes during upload.
+      pull-requests: write # Required so the Crowdin GitHub Action can use GITHUB_TOKEN for pull request operations when needed.
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -9,10 +9,10 @@ permissions: {}
 
 jobs:
   call-crowdin-upload-workflow:
-    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: write      # Required so the Crowdin GitHub Action can use GITHUB_TOKEN for repository writes during upload.
       pull-requests: write # Required so the Crowdin GitHub Action can use GITHUB_TOKEN for pull request operations when needed.
+    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
+      actions: write # Required for actions/cache to read and save Composer dependency cache.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read # Required to clone the repo.
       actions: write # Required for actions/cache to read and save Composer dependency cache.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push the release branch and commits.
       pull-requests: write # Required for the reusable workflow to open the release pull request (also uses gh with GITHUB_TOKEN).
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -22,10 +22,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
       contents: write      # Required for the reusable workflow to push the release branch and commits.
       pull-requests: write # Required for the reusable workflow to open the release pull request (also uses gh with GITHUB_TOKEN).
+    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -13,15 +13,19 @@ on:
         default: 'patch'
         required: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to push the release branch and commits.
+      pull-requests: write # Required for the reusable workflow to open the release pull request (also uses gh with GITHUB_TOKEN).
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # peter-evans/repository-dispatch uses secrets.WEBHOOK_TOKEN, not the default GITHUB_TOKEN.
+    timeout-minutes: 10
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # peter-evans/repository-dispatch uses secrets.WEBHOOK_TOKEN, not the default GITHUB_TOKEN.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 8 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint.yml`, `newfold-prep-release.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `1ffd0bd` |
| Timeouts commit | `bd87814` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `auto-translate.yml` (added required comment + `permissions: {}` block; previously only bare `permissions: {}` without the mandated comment) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` (replaced non-empty `permissions:` with default-deny block) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` (replaced non-empty `permissions:` with default-deny block) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-download.yml` (replaced non-empty `permissions:` with default-deny block) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `newfold-prep-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read`, `actions: write` [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive | setup | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive | bluehost | `contents: read` [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive | bluehost-dev | `contents: read` [3] |
| brand-plugin-test-playwright.yml | 4 jobs were missing a scoped `permissions:` directive | hostgator | `contents: read` [3] |
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: write`, `pull-requests: write` [3] |
| i18n-crowdin-download.yml | 1 job needed an explicit scoped `permissions:` directive after removing workflow-wide grants | call-crowdin-workflow | `contents: read` [2] |
| auto-translate.yml | 1 job already had permissions, but they were repositioned immediately after `uses:` and documented with inline comments (no new scopes versus prior intent) | translate | `contents: write`, `pull-requests: write` (clarified; same scopes as before) [3] |
| newfold-prep-release.yml | 0 jobs were missing a scoped `permissions:` directive | prep-release | `contents: write`, `pull-requests: write` (reordered after `uses:` and documented with inline comments; same scopes as before) [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `brand-plugin-test-playwright.yml` :: workflow: BEFORE top-level `permissions: contents: read` -> AFTER top-level `permissions: {}` plus job-level grants -- Required default-deny workflow pattern; avoids granting repository read to the setup job that does not clone the repo. -- [3] |
| 2 | `codecoverage-main.yml` :: workflow: BEFORE top-level `permissions: contents: read` -> AFTER top-level `permissions: {}` -- Required default-deny workflow pattern; repository access is enforced at the job that checks out or calls reusables. -- [3] |
| 3 | `i18n-crowdin-download.yml` :: `call-crowdin-workflow`: BEFORE workflow-level `contents: write`, `pull-requests: write` -> AFTER job-level `contents: read` -- The reusable workflow uses `secrets.NEWFOLD_ACCESS_TOKEN` as `GITHUB_TOKEN` for the Crowdin action; checkout still uses the job token and only needs clone access for a private repository. -- [2] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| lint.yml | phpcs | `30` | PHPCS, Composer install, and cache restore/save typically finish well under half an hour; caps runaway spend if a step hangs. |
| brand-plugin-test-playwright.yml | setup | `10` | Only derives the branch name from environment variables. |
| brand-plugin-test-playwright.yml | bluehost | `120` | Spins up wp-env, installs Playwright browsers, and runs plugin plus module Playwright suites; budgeted for heavier e2e runs. |
| brand-plugin-test-playwright.yml | bluehost-dev | `120` | Same rationale as `bluehost`, against the `develop` plugin branch. |
| brand-plugin-test-playwright.yml | hostgator | `120` | Same rationale as `bluehost`, for the HostGator plugin repo. |
| satis-update.yml | webhook | `10` | Computes tag metadata and fires a repository dispatch; should complete quickly. |
| codecoverage-main.yml | get-repo-name | `10` | Single shell snippet with no heavy work. |
| codecoverage-main.yml | codecoverage | `120` | Reusable workflow runs PHPUnit/Codeception across many PHP versions and merges coverage; longer wall time is plausible. |
| newfold-prep-release.yml | prep-release | `60` | Reusable workflow installs dependencies, bumps versions, builds, and prepares a pull request; allow headroom beyond lightweight jobs. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `30` | Crowdin upload against a typical module repo should finish within this window. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `30` | Crowdin download and PR preparation should remain bounded; prevents a stuck integration from burning minutes indefinitely. |
| auto-translate.yml | translate | `30` | Reusable translation workflow should complete within this window under normal conditions. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `i18n-crowdin-download.yml` still maps only `CROWDIN_PERSONAL_TOKEN` into the reusable workflow secrets block; upstream `newfold-labs/workflows` `i18n-crowdin-download.yml` declares a required `NEWFOLD_ACCESS_TOKEN` secret—confirm whether org-level secret inheritance or an explicit mapping is already guaranteed, otherwise runs may fail at runtime. |
| 2 | Local commits used `git -c commit.gpgsign=false` because signing failed under the agent environment; replay the commits with your normal signing policy if required. |
| 3 | Third-party and reusable workflows (`newfold-labs/workflows`, `peter-evans/repository-dispatch`, Crowdin action, cache/get-diff actions) were assessed via public workflow sources and GitHub permissions documentation; confirm nothing organization-specific bypasses these assumptions. |


