### PR TITLE
Fix marketplace filter dropdown counts to match displayed items

### DIFF
--- a/components/marketplaceBody/Body.js
+++ b/components/marketplaceBody/Body.js
@@ -126,7 +126,8 @@ export const Body = ( { constants, methods } ) => {
 	 * (`items`). Those two numbers can diverge when the feed does not contain every
 	 * product the catalog has for a category, leaving the dropdown count higher than
 	 * the number of items actually displayed. Recompute each count from the feed
-	 * using the same matching logic as `filterProducts` so the dropdown count always
+	 * using the same predicate `MarketplaceList` uses to render the cards
+	 * (`item.categories.includes( category.title )`) so the dropdown count always
 	 * matches the rendered items.
 	 *
 	 * @param Array      categories
@@ -142,10 +143,7 @@ export const Body = ( { constants, methods } ) => {
 		const thecategories = [];
 		categories.forEach( ( cat ) => {
 			cat.products_count = items.filter( ( product ) =>
-				product.categories.some(
-					( element ) =>
-						element.toLowerCase() === cat.name.toLowerCase()
-				)
+				product.categories.includes( cat.title )
 			).length;
 			cat.currentCount = constants.perPage;
 			cat.className = 'newfold-marketplace-category-' + cat.name;

--- a/components/marketplaceBody/Body.js
+++ b/components/marketplaceBody/Body.js
@@ -41,7 +41,7 @@ export const Body = ( { constants, methods } ) => {
 								name: 'all',
 								products_count: items.length,
 							},
-							...validateCategories( response.categories.data )
+							...validateCategories( response.categories.data, items )
 						]
 					);
 				}
@@ -120,17 +120,33 @@ export const Body = ( { constants, methods } ) => {
 
 	/**
 	 * Validate provided category data
+	 *
+	 * The category endpoint reports a server-side `products_count` for the whole
+	 * catalog, but the cards are rendered by filtering the returned products feed
+	 * (`items`). Those two numbers can diverge when the feed does not contain every
+	 * product the catalog has for a category, leaving the dropdown count higher than
+	 * the number of items actually displayed. Recompute each count from the feed
+	 * using the same matching logic as `filterProducts` so the dropdown count always
+	 * matches the rendered items.
+	 *
 	 * @param Array      categories
+	 * @param Array      items      products returned by the marketplace feed
 	 * @param categories
 	 * @return
 	 */
-	const validateCategories = ( categories ) => {
+	const validateCategories = ( categories, items ) => {
 		if ( ! categories.length ) {
 			return [];
 		}
 
 		const thecategories = [];
 		categories.forEach( ( cat ) => {
+			cat.products_count = items.filter( ( product ) =>
+				product.categories.some(
+					( element ) =>
+						element.toLowerCase() === cat.name.toLowerCase()
+				)
+			).length;
 			cat.currentCount = constants.perPage;
 			cat.className = 'newfold-marketplace-category-' + cat.name;
 


### PR DESCRIPTION
The category dropdown showed each category's server-side products_count from the categories endpoint, while the rendered cards came from filtering the returned products feed. When the feed does not contain every catalog product for a category, the counts diverged (e.g. SEO showed 8 but only 2 items rendered).

Recompute each category's products_count from the products feed using the same matching logic as filterProducts so the dropdown count always matches the number of items displayed.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->